### PR TITLE
Install php5-sybase package for Microsoft SQL support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:jessie
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
-    apt-get install -y curl apache2 php5 php5-common php5-cli php5-curl php5-json php5-mcrypt php5-gd php5-mysql mysql-client git php-pear php5-dev && \
+    apt-get install -y curl apache2 php5 php5-common php5-cli php5-curl php5-json php5-mcrypt php5-gd php5-mysql php5-sybase mysql-client git php-pear php5-dev && \
     rm -rf /var/lib/apt/lists/*
 
 RUN pecl install mongo


### PR DESCRIPTION
The Dreamfactory interface provides an option for Microsoft SQL, but the Docker image does not have the PHP drivers installed. Added php5-sybase to list of apt-get packages to install resolved the issue for us.